### PR TITLE
[IMPROVEMENT] disable next button in init if following# < 50

### DIFF
--- a/commands/follow.js
+++ b/commands/follow.js
@@ -48,7 +48,8 @@ module.exports = {
                                 new ButtonBuilder()
                                     .setCustomId('next')
                                     .setLabel('>')
-                                    .setStyle(ButtonStyle.Primary),
+                                    .setStyle(ButtonStyle.Primary)
+                                    .setDisabled(embed.length < 50),
                             );
                         interaction.editReply({ embeds: [embed], components: [row] });
                     });


### PR DESCRIPTION
Currently if following number less than 1 page size, ">" button is enabled and click on it will cause request error.
Disabled the button by default in this PR if user following number < 50 aka 1 page size